### PR TITLE
Update actions to use Node.js 24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -73,7 +73,7 @@ runs:
 
     - name: Show warnings report as sticky PR comment
       if: ${{ inputs.add-pr-comment == 'true' && github.event_name == 'pull_request' }}
-      uses: marocchino/sticky-pull-request-comment@v2
+      uses: marocchino/sticky-pull-request-comment@v3
       with:
         header: ${{ inputs.pr-comment-header }}
         recreate: true
@@ -81,7 +81,7 @@ runs:
 
     - name: Upload warnings reports as job artifact
       if: ${{ inputs.upload-artifact == 'true' }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: ${{ inputs.artifact-name }}
         path: warnings.md


### PR DESCRIPTION
The actions marocchino/sticky-pull-request-comment@v2 and actions/upload-artifact@v4 trigger a deprecation warning because they use Node.js 20. Apparently after June 2nd, 2026 at least Node.js 24 is required, so I updated the actions to v3 and v6, respectively.