### PR TITLE
Update actions to use Node.js 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
   test-ubuntu:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Copy test build logs
         run: cp -r .github/data/* .
@@ -35,7 +35,7 @@ jobs:
   test-windows:
     runs-on: windows-2022
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Copy test build logs
         run: cp -r .github/data/* .
@@ -52,7 +52,7 @@ jobs:
   check-reuse-compliance:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Check REUSE compliance
-        uses: fsfe/reuse-action@v5
+        uses: fsfe/reuse-action@v6

--- a/action.yml
+++ b/action.yml
@@ -73,7 +73,7 @@ runs:
 
     - name: Show warnings report as sticky PR comment
       if: ${{ inputs.add-pr-comment == 'true' && github.event_name == 'pull_request' }}
-      uses: marocchino/sticky-pull-request-comment@v2
+      uses: marocchino/sticky-pull-request-comment@v3
       with:
         header: ${{ inputs.pr-comment-header }}
         recreate: true
@@ -81,7 +81,7 @@ runs:
 
     - name: Upload warnings reports as job artifact
       if: ${{ inputs.upload-artifact == 'true' }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: ${{ inputs.artifact-name }}
         path: warnings.md


### PR DESCRIPTION
Some actions trigger a deprecation warning because they use Node.js 20. Apparently after June 2nd, 2026 at least Node.js 24 is required, so I updated those actions accordingly.